### PR TITLE
fix: update moduleNameMapper jest config to recognize .js files

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -9,5 +9,8 @@ export default {
     '!<rootDir>/src/**/*.spec.ts',
     '!<rootDir>/src/**/*.test.ts',
     '!<rootDir>/src/**/*.d.ts'
-  ]
+  ],
+  moduleNameMapper: {
+    '(.+)\\.js': '$1'
+  },
 };


### PR DESCRIPTION
the "cannot find module *.js from *.spec.ts" is a known Typescript + Node + Jest combination issue.

Refer the following for more info:
https://stackoverflow.com/questions/73735202/typescript-jest-imports-with-js-extension-cause-error-cannot-find-module https://github.com/kulshekhar/ts-jest/issues/1057#issuecomment-1441733977